### PR TITLE
Bugfix: Python3 SSLSocket missing imports.

### DIFF
--- a/gevent/_ssl3.py
+++ b/gevent/_ssl3.py
@@ -13,7 +13,7 @@ import ssl as __ssl__
 _ssl = __ssl__._ssl
 
 import errno
-from gevent.socket import socket, timeout_default
+from gevent.socket import socket, timeout_default, SOL_SOCKET, SO_TYPE, SOCK_STREAM
 from gevent.socket import error as socket_error
 
 


### PR DESCRIPTION
SSLSocket was broken on Python3 due to missing imports.

``` python
  File "/usr/local/lib/python3.3/http/client.py", line 1206, in connect
    server_hostname=server_hostname)
  File "gevent/_ssl3.py", line 50, in wrap_socket
    _context=self)
  File "gevent/_ssl3.py", line 91, in __init__
    if sock.getsockopt(SOL_SOCKET, SO_TYPE) != SOCK_STREAM:
NameError: global name 'SOL_SOCKET' is not defined
```
